### PR TITLE
Fixed bug on Windows where emojis were not supported to be printed.

### DIFF
--- a/src/rtgs_lab_tools/device_monitoring/scheduled_device_monitoring.sh
+++ b/src/rtgs_lab_tools/device_monitoring/scheduled_device_monitoring.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export PYTHONUTF8=1	# ensure proper encoding so that this script can print emojis without error
 
 # Scheduled Device Monitoring Script for CRON
 # Based on .github/workflows/daily-device-monitoring.yml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,16 +32,14 @@ def mock_config():
 def temp_env_file():
     """Create temporary .env file for testing."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
-        f.write(
-            """DB_HOST=test-host
+        f.write("""DB_HOST=test-host
 DB_PORT=5432
 DB_NAME=test_db
 DB_USER=test_user
 DB_PASSWORD=test_password
 PARTICLE_ACCESS_TOKEN=test_token
 CDS_API_KEY=test_cds_key
-"""
-        )
+""")
         temp_path = f.name
 
     yield temp_path


### PR DESCRIPTION
This caused the whole device monitoring pipeline to fail. This happened because Windows was not using UTF-8 encoding. Adding a line in `scheduled_device_monitoring.sh` to force UTF-8 encoding fixed this issue.